### PR TITLE
SCOR-15-Refactor-casbin-roles-loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ mock:
 gin:
 	GIN_MODE=release gin -i run main.go --all --port 8080
 
-.PHONY: db_docs db_schema
+.PHONY: db_docs db_schema test

--- a/api/server.go
+++ b/api/server.go
@@ -20,7 +20,7 @@ type Server struct {
 }
 
 func (s *Server) setupRouter() {
-	enforcer, err := security.NewEnforcer(s.config)
+	enforcer, err := security.NewEnforcer(s.config, security.SecurityResources())
 	if err != nil {
 		log.Fatal().Err(err).Msg("failed to create casbin enforcer")
 	}

--- a/security/roles.go
+++ b/security/roles.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"embed"
 	"encoding/csv"
-	casbin "github.com/casbin/casbin/v2"
+	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	"github.com/kwalter26/scoreit-api-go/util"
 	"github.com/rs/zerolog/log"
@@ -16,65 +16,34 @@ import (
 	"os"
 )
 
-// res is a file server that serves embedded static files.
-//
-//go:embed resources
-var res embed.FS
-
-// getFileContent reads the content of a file specified by filePath.
-// If the file exists, it returns the file contents as a byte slice ([]byte).
-// If the file does not exist, it loads the default file specified by defaultPath and returns its contents.
-// The fileType parameter is used for logging purposes.
-// Returns []byte and error.
-func getFileContent(filePath string, defaultPath string, fileType string) ([]byte, error) {
-	var fileBytes []byte
-	var err error
-
-	if _, fileErr := os.Stat(filePath); fileErr == nil {
-		log.Info().Msgf("Loading %s file %s", fileType, filePath)
-		fileBytes, err = os.ReadFile(filePath)
-	} else {
-		log.Warn().Msgf("%s File '%s' does not exist. Loading default %s file %s", fileType, filePath, fileType, defaultPath)
-		fileBytes, err = res.ReadFile(defaultPath)
-	}
-
-	return fileBytes, err
+// aclFiles represents a type that loads ACL files.
+type aclFiles struct {
+	res      *embed.FS
+	model    model.Model
+	policies [][]string
 }
 
-// getModelBytes reads the content of the Casbin model file specified by config.CasbinModelPath.
-// If the file exists, it returns the file contents as a byte slice ([]byte).
-// If the file does not exist, it loads the default model file "resources/authz_model.conf" and returns its contents.
-// The "Model" parameter is used for logging purposes.
-// Requires a valid util.Config instance as a parameter.
-// Returns the byte slice of the model file and an error.
-func getModelBytes(config util.Config) ([]byte, error) {
-	return getFileContent(config.CasbinModelPath, "resources/authz_model.conf", "Model")
+// Model returns the value of the model field in aclFiles.
+// It returns an instance of model.Model.
+func (sf aclFiles) Model() model.Model {
+	return sf.model
 }
 
-// getPolicyBytes reads the content of the Casbin Policy file specified by config.CasbinPolicyPath.
-// If the file exists, it returns the file contents as a byte slice ([]byte).
-// If the file does not exist, it loads the default policy file "resources/authz_policy.csv" and returns its contents.
-// The "Policy" parameter is used for logging purposes.
-// Requires a valid util.Config instance as a parameter.
-// Returns the byte slice of the policy file and an error.
-func getPolicyBytes(config util.Config) ([]byte, error) {
-	return getFileContent(config.CasbinPolicyPath, "resources/authz_policy.csv", "Policy")
+// Policies returns the value of the policies field in aclFiles.
+// It returns a two-dimensional slice of strings, representing the policies.
+// Each inner slice contains the four parameters of a policy: subject, object, action, and effect.
+func (sf aclFiles) Policies() [][]string {
+	return sf.policies
 }
 
-// NewEnforcer creates a new casbin enforcer with the provided configuration.
-// It loads the model bytes and policy bytes from the specified paths in the config.
-// Then it initializes the casbin enforcer with the loaded model.
-// Next, it parses the policy bytes as a CSV file and adds the policies to the enforcer.
-// If any policy does not contain the required 4 parameters, it logs a warning.
-// If any error occurs during the process, it returns nil and the error.
-// Otherwise, it returns the initialized enforcer and nil error.
-func NewEnforcer(config util.Config) (*casbin.Enforcer, error) {
-	modelBytes, err := getModelBytes(config)
+func newSecurityFiles(config util.Config, fs *embed.FS) (*aclFiles, error) {
+	securityFiles := &aclFiles{res: fs}
+	modelBytes, err := securityFiles.getModelBytes(config)
 	if err != nil {
 		return nil, err
 	}
 
-	policyBytes, err := getPolicyBytes(config)
+	policyBytes, err := securityFiles.getPolicyBytes(config)
 	if err != nil {
 		return nil, err
 	}
@@ -89,13 +58,69 @@ func NewEnforcer(config util.Config) (*casbin.Enforcer, error) {
 	if err != nil {
 		return nil, err
 	}
+	return &aclFiles{res: fs, model: modelFromString, policies: policies}, nil
+}
 
-	e, err := casbin.NewEnforcer(modelFromString)
+// getFileContent reads the content of a file specified by filePath.
+// If the file exists, it returns the file contents as a byte slice ([]byte).
+// If the file does not exist, it loads the default file specified by defaultPath and returns its contents.
+// The fileType parameter is used for logging purposes.
+// Returns []byte and error.
+func (sf aclFiles) getFileContent(filePath string, defaultPath string, fileType string) ([]byte, error) {
+	var fileBytes []byte
+	var err error
+
+	if _, fileErr := os.Stat(filePath); fileErr == nil {
+		log.Info().Msgf("Loading %s file %s", fileType, filePath)
+		fileBytes, err = os.ReadFile(filePath)
+	} else {
+		log.Warn().Msgf("%s File '%s' does not exist. Loading default %s file %s", fileType, filePath, fileType, defaultPath)
+		fileBytes, err = sf.res.ReadFile(defaultPath)
+	}
+
+	return fileBytes, err
+}
+
+// getModelBytes reads the content of the Casbin model file specified by config.CasbinModelPath.
+// If the file exists, it returns the file contents as a byte slice ([]byte).
+// If the file does not exist, it loads the default model file "resources/authz_model.conf" and returns its contents.
+// The "Model" parameter is used for logging purposes.
+// Requires a valid util.Config instance as a parameter.
+// Returns the byte slice of the model file and an error.
+func (sf aclFiles) getModelBytes(config util.Config) ([]byte, error) {
+	return sf.getFileContent(config.CasbinModelPath, "resources/authz_model.conf", "Model")
+}
+
+// getPolicyBytes reads the content of the Casbin Policy file specified by config.CasbinPolicyPath.
+// If the file exists, it returns the file contents as a byte slice ([]byte).
+// If the file does not exist, it loads the default policy file "resources/authz_policy.csv" and returns its contents.
+// The "Policy" parameter is used for logging purposes.
+// Requires a valid util.Config instance as a parameter.
+// Returns the byte slice of the policy file and an error.
+func (sf aclFiles) getPolicyBytes(config util.Config) ([]byte, error) {
+	return sf.getFileContent(config.CasbinPolicyPath, "resources/authz_policy.csv", "Policy")
+}
+
+// NewEnforcer creates a new casbin enforcer with the provided configuration.
+// It loads the model bytes and policy bytes from the specified paths in the config.
+// Then it initializes the casbin enforcer with the loaded model.
+// Next, it parses the policy bytes as a CSV file and adds the policies to the enforcer.
+// If any policy does not contain the required 4 parameters, it logs a warning.
+// If any error occurs during the process, it returns nil and the error.
+// Otherwise, it returns the initialized enforcer and nil error.
+func NewEnforcer(config util.Config, fs *embed.FS) (*casbin.Enforcer, error) {
+
+	securityFiles, err := newSecurityFiles(config, fs)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, policy := range policies {
+	e, err := casbin.NewEnforcer(securityFiles.Model())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, policy := range securityFiles.Policies() {
 		if len(policy) == 4 {
 			if ok, err := e.AddNamedPolicy(
 				strings.TrimSpace(policy[0]),

--- a/security/roles.go
+++ b/security/roles.go
@@ -1,3 +1,6 @@
+// Package security provides utilities for building
+// authorization structures in a Go application using
+// casbin.
 package security
 
 import (
@@ -13,37 +16,69 @@ import (
 	"os"
 )
 
+// res is a file server that serves embedded static files.
+//
 //go:embed resources
 var res embed.FS
 
+// getFileContent reads the content of a file specified by filePath.
+// If the file exists, it returns the file contents as a byte slice ([]byte).
+// If the file does not exist, it loads the default file specified by defaultPath and returns its contents.
+// The fileType parameter is used for logging purposes.
+// Returns []byte and error.
+func getFileContent(filePath string, defaultPath string, fileType string) ([]byte, error) {
+	var fileBytes []byte
+	var err error
+
+	if _, fileErr := os.Stat(filePath); fileErr == nil {
+		log.Info().Msgf("Loading %s file %s", fileType, filePath)
+		fileBytes, err = os.ReadFile(filePath)
+	} else {
+		log.Warn().Msgf("%s File '%s' does not exist. Loading default %s file %s", fileType, filePath, fileType, defaultPath)
+		fileBytes, err = res.ReadFile(defaultPath)
+	}
+
+	return fileBytes, err
+}
+
+// getModelBytes reads the content of the Casbin model file specified by config.CasbinModelPath.
+// If the file exists, it returns the file contents as a byte slice ([]byte).
+// If the file does not exist, it loads the default model file "resources/authz_model.conf" and returns its contents.
+// The "Model" parameter is used for logging purposes.
+// Requires a valid util.Config instance as a parameter.
+// Returns the byte slice of the model file and an error.
+func getModelBytes(config util.Config) ([]byte, error) {
+	return getFileContent(config.CasbinModelPath, "resources/authz_model.conf", "Model")
+}
+
+// getPolicyBytes reads the content of the Casbin Policy file specified by config.CasbinPolicyPath.
+// If the file exists, it returns the file contents as a byte slice ([]byte).
+// If the file does not exist, it loads the default policy file "resources/authz_policy.csv" and returns its contents.
+// The "Policy" parameter is used for logging purposes.
+// Requires a valid util.Config instance as a parameter.
+// Returns the byte slice of the policy file and an error.
+func getPolicyBytes(config util.Config) ([]byte, error) {
+	return getFileContent(config.CasbinPolicyPath, "resources/authz_policy.csv", "Policy")
+}
+
+// NewEnforcer creates a new casbin enforcer with the provided configuration.
+// It loads the model bytes and policy bytes from the specified paths in the config.
+// Then it initializes the casbin enforcer with the loaded model.
+// Next, it parses the policy bytes as a CSV file and adds the policies to the enforcer.
+// If any policy does not contain the required 4 parameters, it logs a warning.
+// If any error occurs during the process, it returns nil and the error.
+// Otherwise, it returns the initialized enforcer and nil error.
 func NewEnforcer(config util.Config) (*casbin.Enforcer, error) {
-
-	var modelBytes []byte
-	var policyBytes []byte
-
-	if _, err := os.Stat(config.CasbinModelPath); err == nil {
-		log.Info().Msgf("Loading file %s", config.CasbinModelPath)
-		modelBytes, err = os.ReadFile(config.CasbinModelPath)
-	} else {
-		log.Warn().Msgf("File '%s' does not exist", config.CasbinModelPath)
-		log.Info().Msgf("Loading default file %s", "resources/authz_model.conf")
-		modelBytes, err = res.ReadFile("resources/authz_model.conf")
-		if err != nil {
-			return nil, err
-		}
+	modelBytes, err := getModelBytes(config)
+	if err != nil {
+		return nil, err
 	}
 
-	if _, err := os.Stat(config.CasbinPolicyPath); err == nil {
-		log.Info().Msgf("Loading file %s", config.CasbinPolicyPath)
-		policyBytes, err = os.ReadFile(config.CasbinPolicyPath)
-	} else {
-		log.Warn().Msgf("File '%s' does not exist", config.CasbinPolicyPath)
-		log.Info().Msgf("Loading default file %s", "resources/authz_policy.csv")
-		policyBytes, err = res.ReadFile("resources/authz_policy.csv")
-		if err != nil {
-			return nil, err
-		}
+	policyBytes, err := getPolicyBytes(config)
+	if err != nil {
+		return nil, err
 	}
+
 	modelFromString, err := model.NewModelFromString(string(modelBytes))
 	if err != nil {
 		return nil, err
@@ -56,6 +91,10 @@ func NewEnforcer(config util.Config) (*casbin.Enforcer, error) {
 	}
 
 	e, err := casbin.NewEnforcer(modelFromString)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, policy := range policies {
 		if len(policy) == 4 {
 			if ok, err := e.AddNamedPolicy(
@@ -66,20 +105,27 @@ func NewEnforcer(config util.Config) (*casbin.Enforcer, error) {
 			); ok {
 				log.Info().Msgf("Added policy: %s", policy)
 			} else {
-				log.Warn().Msgf("Failed to add policy: %s", policy)
+				log.Warn().Msgf("Failed to add policy: %s with error %s", policy, err)
 				return nil, err
 			}
 		} else {
-			log.Warn().Msgf("Failed to add policy: %s", policy)
+			log.Warn().Msgf("Policy '%s' does not contain required 4 params", policy)
 		}
 	}
-
 	return e, nil
 }
 
+// Role type tracks the role of a user
 type Role string
 
+// UserRole is the role for normal users
 var UserRole Role = "user"
+
+// AdminRole is the role for admin users
 var AdminRole Role = "admin"
+
+// UserRoles includes all roles a user can have
 var UserRoles = []Role{UserRole}
+
+// AdminRoles includes all roles an admin can have
 var AdminRoles = []Role{AdminRole}

--- a/security/roles_test.go
+++ b/security/roles_test.go
@@ -1,0 +1,98 @@
+package security
+
+import (
+	"embed"
+	"github.com/kwalter26/scoreit-api-go/test"
+	"github.com/kwalter26/scoreit-api-go/util"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestNewEnforcer(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  util.Config
+		fs      *embed.FS
+		wantErr bool
+	}{
+		{
+			name:    "valid case",
+			config:  util.Config{CasbinModelPath: "../test/resources/test_authz_model.conf", CasbinPolicyPath: "../test/resources/test_authz_policy.csv"},
+			fs:      test.SecurityResources(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid model path",
+			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "../test/test_authz_policy.csv"},
+			fs:      test.SecurityResources(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid policy path",
+			config:  util.Config{CasbinModelPath: "../test/test_authz_model.conf", CasbinPolicyPath: "path/to/invalid/policy"},
+			fs:      test.SecurityResources(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid model and policy paths. uses embedded fs",
+			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "path/to/invalid/policy"},
+			fs:      test.SecurityResources(),
+			wantErr: false,
+		},
+		{
+			name:    "invalid embedded fs",
+			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "path/to/invalid/policy"},
+			fs:      &embed.FS{},
+			wantErr: true,
+		},
+		{
+			name:    "bad policy invalid csv",
+			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "../test/bad_authz_policy.csv"},
+			fs:      test.SecurityResources(),
+			wantErr: true,
+		},
+		{
+			name:    "bad model embedded fs",
+			config:  util.Config{CasbinModelPath: "../test/bad_authz_model.conf", CasbinPolicyPath: "path/to/invalid/policy"},
+			fs:      test.SecurityResources(),
+			wantErr: true,
+		},
+	}
+
+	// Create a file named test_authz_model.conf
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fileA, errA := os.Create("test_authz_model.conf")
+			if errA != nil {
+				t.Fatal(errA)
+			}
+			defer func(fileA *os.File) {
+				err := fileA.Close()
+				require.NoError(t, err)
+			}(fileA)
+
+			// Create a file named test_authz_policy.csv
+			fileB, errB := os.Create("test_authz_policy.csv")
+			if errB != nil {
+				t.Fatal(errB)
+			}
+			defer func(fileB *os.File) {
+				err := fileB.Close()
+				require.NoError(t, err)
+			}(fileB)
+
+			_, err := NewEnforcer(tt.config, tt.fs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEnforcer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			err = os.Remove("test_authz_model.conf")
+			require.NoError(t, err)
+			err = os.Remove("test_authz_policy.csv")
+			require.NoError(t, err)
+		})
+	}
+
+}

--- a/security/roles_test.go
+++ b/security/roles_test.go
@@ -9,6 +9,17 @@ import (
 	"testing"
 )
 
+const (
+	validModelPath    = "../test/resources/test_authz_model.conf"
+	validPolicyPath   = "../test/resources/test_authz_policy.csv"
+	invalidModelPath  = "path/to/invalid/model"
+	invalidPolicyPath = "path/to/invalid/policy"
+	badPolicyPath     = "../test/bad_authz_policy.csv"
+	badModelPath      = "../test/bad_authz_model.conf"
+	testModelConfFile = "test_authz_model.conf"
+	testPolicyCsvFile = "test_authz_policy.csv"
+)
+
 func TestNewEnforcer(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -18,53 +29,52 @@ func TestNewEnforcer(t *testing.T) {
 	}{
 		{
 			name:    "valid case",
-			config:  util.Config{CasbinModelPath: "../test/resources/test_authz_model.conf", CasbinPolicyPath: "../test/resources/test_authz_policy.csv"},
+			config:  util.Config{CasbinModelPath: validModelPath, CasbinPolicyPath: validPolicyPath},
 			fs:      test.SecurityResources(),
 			wantErr: false,
 		},
 		{
 			name:    "invalid model path",
-			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "../test/test_authz_policy.csv"},
+			config:  util.Config{CasbinModelPath: invalidModelPath, CasbinPolicyPath: validPolicyPath},
 			fs:      test.SecurityResources(),
 			wantErr: false,
 		},
 		{
 			name:    "invalid policy path",
-			config:  util.Config{CasbinModelPath: "../test/test_authz_model.conf", CasbinPolicyPath: "path/to/invalid/policy"},
+			config:  util.Config{CasbinModelPath: validModelPath, CasbinPolicyPath: invalidPolicyPath},
 			fs:      test.SecurityResources(),
 			wantErr: false,
 		},
 		{
 			name:    "invalid model and policy paths. uses embedded fs",
-			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "path/to/invalid/policy"},
+			config:  util.Config{CasbinModelPath: invalidModelPath, CasbinPolicyPath: invalidPolicyPath},
 			fs:      test.SecurityResources(),
 			wantErr: false,
 		},
 		{
 			name:    "invalid embedded fs",
-			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "path/to/invalid/policy"},
+			config:  util.Config{CasbinModelPath: invalidModelPath, CasbinPolicyPath: invalidPolicyPath},
 			fs:      &embed.FS{},
 			wantErr: true,
 		},
 		{
 			name:    "bad policy invalid csv",
-			config:  util.Config{CasbinModelPath: "path/to/invalid/model", CasbinPolicyPath: "../test/bad_authz_policy.csv"},
+			config:  util.Config{CasbinModelPath: invalidModelPath, CasbinPolicyPath: badPolicyPath},
 			fs:      test.SecurityResources(),
 			wantErr: true,
 		},
 		{
 			name:    "bad model embedded fs",
-			config:  util.Config{CasbinModelPath: "../test/bad_authz_model.conf", CasbinPolicyPath: "path/to/invalid/policy"},
+			config:  util.Config{CasbinModelPath: badModelPath, CasbinPolicyPath: invalidPolicyPath},
 			fs:      test.SecurityResources(),
 			wantErr: true,
 		},
 	}
 
-	// Create a file named test_authz_model.conf
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fileA, errA := os.Create("test_authz_model.conf")
+			// Create a file named test_authz_model.conf
+			fileA, errA := os.Create(testModelConfFile)
 			if errA != nil {
 				t.Fatal(errA)
 			}
@@ -74,7 +84,7 @@ func TestNewEnforcer(t *testing.T) {
 			}(fileA)
 
 			// Create a file named test_authz_policy.csv
-			fileB, errB := os.Create("test_authz_policy.csv")
+			fileB, errB := os.Create(testPolicyCsvFile)
 			if errB != nil {
 				t.Fatal(errB)
 			}
@@ -88,9 +98,9 @@ func TestNewEnforcer(t *testing.T) {
 				t.Errorf("NewEnforcer() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			err = os.Remove("test_authz_model.conf")
+			err = os.Remove(testModelConfFile)
 			require.NoError(t, err)
-			err = os.Remove("test_authz_policy.csv")
+			err = os.Remove(testPolicyCsvFile)
 			require.NoError(t, err)
 		})
 	}

--- a/security/security_data.go
+++ b/security/security_data.go
@@ -1,0 +1,12 @@
+package security
+
+import (
+	"embed"
+)
+
+//go:embed resources
+var res embed.FS
+
+func SecurityResources() *embed.FS {
+	return &res
+}

--- a/test/bad_authz_model.conf
+++ b/test/bad_authz_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[matchers]
+m = (g(r.sub, p.sub)) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/test/bad_authz_policy.csv
+++ b/test/bad_authz_policy.csv
@@ -1,0 +1,4 @@
+p, ANONYMOUS, /api/v1/users, POST
+p, ANONYMOUS, /api/v1/auth/login, POST
+p, user, /api/v1/*, *
+p, admin, /api/v1/*

--- a/test/resources/authz_model.conf
+++ b/test/resources/authz_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = (g(r.sub, p.sub)) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/test/resources/authz_policy.csv
+++ b/test/resources/authz_policy.csv
@@ -1,0 +1,3 @@
+p, ANONYMOUS, /api/v1/users, POST
+p, ANONYMOUS, /api/v1/auth/login, POST
+p, user, /api/v1/*, *

--- a/test/security_data.go
+++ b/test/security_data.go
@@ -1,0 +1,12 @@
+package test
+
+import (
+	"embed"
+)
+
+//go:embed resources
+var res embed.FS
+
+func SecurityResources() *embed.FS {
+	return &res
+}

--- a/test/test_authz_model.conf
+++ b/test/test_authz_model.conf
@@ -1,0 +1,14 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj, act
+
+[role_definition]
+g = _, _
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = (g(r.sub, p.sub)) && keyMatch(r.obj, p.obj) && (r.act == p.act || p.act == "*")

--- a/test/test_authz_policy.csv
+++ b/test/test_authz_policy.csv
@@ -1,0 +1,3 @@
+p, ANONYMOUS, /api/v1/users, POST
+p, ANONYMOUS, /api/v1/auth/login, POST
+p, user, /api/v1/*, *


### PR DESCRIPTION
Updated the security roles functionality by breaking down the `NewEnforcer` function into `getModelBytes` and `getPolicyBytes` functions for more modularity. Also, clarified the role of each function and variable through comprehensive comments to improve code readability and maintainability

SCOR-15.